### PR TITLE
use subversion-agnostic Python commands in install.sh scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,7 @@ algorithms/rnntagger/RNNTagger
 # GermanC outputs
 nbs/lemmata/germanc
 nbs/lemmata/germanc-norm
+
+# Backup files
+*~
+\#*

--- a/algorithms/baseline/install.sh
+++ b/algorithms/baseline/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/germalemma/install.sh
+++ b/algorithms/germalemma/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/gpt3/install.sh
+++ b/algorithms/gpt3/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/hanta/install.sh
+++ b/algorithms/hanta/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/rnntagger/install.sh
+++ b/algorithms/rnntagger/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/simplemma/install.sh
+++ b/algorithms/simplemma/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/smorlemma/install.sh
+++ b/algorithms/smorlemma/install.sh
@@ -13,7 +13,7 @@ unzip -q zmorge-20150315.xml.zip
 rm zmorge-20150315.xml.zip
 
 # install venv
-python2.6 -m venv "${SRCDIR}/.venv"
+python2 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"
@@ -26,4 +26,3 @@ cd SMORLemma
 git checkout lemmatiser
 cp ../zmorge-20150315.xml lexicon/wiki-lexicon.xml
 make
-

--- a/algorithms/spacy2/install.sh
+++ b/algorithms/spacy2/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/spacy3.3+/install.sh
+++ b/algorithms/spacy3.3+/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/spacy3/install.sh
+++ b/algorithms/spacy3/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/stanza/install.sh
+++ b/algorithms/stanza/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/trankit/install.sh
+++ b/algorithms/trankit/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 pip install --upgrade pip
 pip install -r "${SRCDIR}/requirements.txt"

--- a/algorithms/treetagger/install.sh
+++ b/algorithms/treetagger/install.sh
@@ -3,7 +3,7 @@
 SRCDIR=$(dirname "$0")
 
 # install venv
-python3.7 -m venv "${SRCDIR}/.venv"
+python3 -m venv "${SRCDIR}/.venv"
 source "${SRCDIR}/.venv/bin/activate"
 
 # install treetagger


### PR DESCRIPTION
make them run on Linux distributions with Python3 newer than v. 3.7 and Python2 newer than v. 2.6